### PR TITLE
Bump Azure Storage version to avoid NSP warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "winston": "^1.1.0"
   },
   "dependencies": {
-    "azure-storage": "^0.6.0"
+    "azure-storage": "^1.3.0"
   },
   "directories": {
     "test": "test"


### PR DESCRIPTION
[nsp](https://nodesecurity.io/opensource) complains about dependencies of the currently used version of `azure-storage`. Bumping to `^1.3.0` addresses this.

Even though this bumps through a major version range looking at the JSDoc for `azure-storage` suggests the API for the table service hasn’t changed.

cc @jpoon 