### PR TITLE
add `nestedMeta` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ The transport accepts the following options:
 * **tableName**: name of the table to log messages (default: `log`)
 * **partitionKey**: table partition key to use (default: `process.env.NODE_ENV`)
 * **silent**: Boolean flag indicating whether to suppress output (default: `false`)
+* **nestedMeta**: store metadata as a JSON document in `meta` column (default: `false`)
 
 Table Entity
 ------------
@@ -43,7 +44,10 @@ Each log entry will create the following entity:
 * **level**: winston logging level
 * **msg**: logging message
 * **createdDateTime**: date log entry created
-* *[metadata properties]*: creates associated property in entity for each given metadata property
+* when `nestedMeta` option is `false`:
+  * *[metadata properties]*: creates associated property in entity for each given metadata property
+* when `nestedMeta` option is `true`:
+  * **meta**: JSON-encoded metadata properties
 
 
 Inspirations/Alternatives

--- a/lib/winston-azuretable.js
+++ b/lib/winston-azuretable.js
@@ -5,6 +5,7 @@ var util    = require('util'),
 // constant
 var DEFAULT_TABLE_NAME = 'log';
 var DEFAULT_IS_SILENT = false;
+var DEFAULT_NESTED_META = false;
 var WINSTON_LOGGER_NAME = 'azurelogger';
 var WINSTON_DEFAULT_LEVEL = 'info';
 var DATE_MAX = new Date(3000, 1);
@@ -37,6 +38,7 @@ var AzureLogger = exports.AzureLogger = function (options) {
     this.partitionKey = options.partitionKey || process.env.NODE_ENV || 'unknown';
     this.tableName = options.tableName || DEFAULT_TABLE_NAME;
     this.silent = options.silent || DEFAULT_IS_SILENT;
+    this.nestedMeta = options.nestedMeta || DEFAULT_NESTED_META;
 
     this.tableService = options.useDevStorage ? 
         azure.createTableService('UseDevelopmentStorage=true') : 
@@ -96,15 +98,19 @@ AzureLogger.prototype.log = function (level, msg, meta, callback) {
         createdDateTime: {'_': new Date() }
     };
 
-    if (meta) { 
-        for (var prop in meta) {
-            var propertyName = prop + '_';
-            if (typeof meta[prop] === 'object') {
-                data[propertyName] = { '_': JSON.stringify(meta[prop]) };
-            } else {
-                data[propertyName] = { '_': meta[prop] };
+    if (meta) {
+        if (this.nestedMeta) {
+            data.meta = { '_': JSON.stringify(meta) };
+        } else {
+            for (var prop in meta) {
+                var propertyName = prop + '_';
+                if (typeof meta[prop] === 'object') {
+                    data[propertyName] = { '_': JSON.stringify(meta[prop]) };
+                } else {
+                    data[propertyName] = { '_': meta[prop] };
+                }
             }
-         }
+        }
     }
 
     this.tableService.insertEntity(this.tableName, data, function(err) {


### PR DESCRIPTION
This PR adds a new boolean option, `nestedMeta`.  When the option is enabled, all metadata is stored as a JSON document in a column named `meta` on the Azure table.  The option defaults to `false`, so default behavior is unchanged (metadata fields are mapped to columns with a `_` suffix, as described in issue #3).

Enabling `nestedMeta` makes winston-azuretable match winston-skywriter's handling of metadata fields, which will help folks migrating from that package.