### PR TITLE
Compatibility issue with winston 3.0.0rc1

### DIFF
--- a/lib/winston-azuretable.js
+++ b/lib/winston-azuretable.js
@@ -68,15 +68,25 @@ util.inherits(AzureLogger, winston.Transport);
 winston.transports.AzureLogger = AzureLogger;
 
 //
-// ### function log (info, [meta], callback)
-// ### @info {Object} Contains 'level'(logging level) and 'message' (Message to log) as properties
+// ### function log (level, msg, [meta], callback)
+// #### @level {string} Level at which to log the message.
+// #### @msg {string} Message to log
 // #### @meta {Object} **Optional** Additional metadata to attach
 // #### @callback {function} Continuation to respond to when complete.
-// Core logging method exposed to Winston Transport. Metadata is optional.
+// Core logging method exposed to Winston. Metadata is optional.
 //
-AzureLogger.prototype.log = function (info, meta, callback) {
-    var self = this;
+AzureLogger.prototype.log = function (level, msg, meta, callback) {
+    var self = this, info;
 
+    // first parameter passed from winston transport(v3.0.0rc1) is object
+    if(typeof level === 'object') {
+        // 3 parameter received        
+        callback = meta;
+        meta = msg;
+        info = level;
+        level = info.level;
+        msg = info.message;
+    }
     if (typeof meta === 'function') {
         callback = meta;
         meta = {};
@@ -93,8 +103,8 @@ AzureLogger.prototype.log = function (info, meta, callback) {
         RowKey: entGen.String((DATE_MAX - Date.now()).toString()),
         hostname: entGen.String(require('os').hostname()),
         pid: entGen.Int32(process.pid),
-        level: entGen.String(info.level),
-        msg: entGen.String(info.message || ''),
+        level: entGen.String(level),
+        msg: entGen.String(msg),
         createdDateTime: entGen.DateTime(new Date()),
     };
 

--- a/lib/winston-azuretable.js
+++ b/lib/winston-azuretable.js
@@ -68,14 +68,13 @@ util.inherits(AzureLogger, winston.Transport);
 winston.transports.AzureLogger = AzureLogger;
 
 //
-// ### function log (level, msg, [meta], callback)
-// #### @level {string} Level at which to log the message.
-// #### @msg {string} Message to log
+// ### function log (info, [meta], callback)
+// ### @info {Object} Contains 'level'(logging level) and 'message' (Message to log) as properties
 // #### @meta {Object} **Optional** Additional metadata to attach
 // #### @callback {function} Continuation to respond to when complete.
-// Core logging method exposed to Winston. Metadata is optional.
+// Core logging method exposed to Winston Transport. Metadata is optional.
 //
-AzureLogger.prototype.log = function (level, msg, meta, callback) {
+AzureLogger.prototype.log = function (info, meta, callback) {
     var self = this;
 
     if (typeof meta === 'function') {
@@ -94,8 +93,8 @@ AzureLogger.prototype.log = function (level, msg, meta, callback) {
         RowKey: entGen.String((DATE_MAX - Date.now()).toString()),
         hostname: entGen.String(require('os').hostname()),
         pid: entGen.Int32(process.pid),
-        level: entGen.String(level),
-        msg: entGen.String(msg),
+        level: entGen.String(info.level),
+        msg: entGen.String(info.message || ''),
         createdDateTime: entGen.DateTime(new Date()),
     };
 


### PR DESCRIPTION
Breaking change from winston 3.0.0rc1
Winston Transport pass  **info** object as parameter instead of level and message.

Added support so that winston azuretable is compatible with winston 2.4.0 and 3.0.0rc1